### PR TITLE
Allow using wm_debug at non-root pathnames (by using relative paths)

### DIFF
--- a/priv/static/wmtrace.js
+++ b/priv/static/wmtrace.js
@@ -706,5 +706,5 @@ window.onload = function() {
         alert('Failed to load background image.');
     };
 
-    bg.src = '/wm_debug/static/http-headers-status-v3.png';
+    bg.src = '../../wm_debug/static/http-headers-status-v3.png';
 };

--- a/templates/log_list.html.eex
+++ b/templates/log_list.html.eex
@@ -2,8 +2,8 @@
   <head>
     <link rel="icon" href="data:;base64,iVBORw0KGgo=">
     <script>
-(new EventSource("/wm_debug/events")).addEventListener("new_query", function(){
-  window.location.reload()  
+(new EventSource("wm_debug/events")).addEventListener("new_query", function(){
+  window.location.reload()
 })
     </script>
   </head>
@@ -11,8 +11,8 @@
     <h1>Last Ewebmachine Logs</h1>
     <ul>
       <%= for conn<-conns do %>
-          <li><%= conn.private.machine_init_at |> :calendar.now_to_local_time |> Ewebmachine.Core.Utils.rfc1123_date %> :  
-              <a href="/wm_debug/log/<%= conn.private.machine_log %>"><%= conn.method %> <%= full_path(conn) %></a></li>
+          <li><%= conn.private.machine_init_at |> :calendar.now_to_local_time |> Ewebmachine.Core.Utils.rfc1123_date %> :
+              <a href="wm_debug/log/<%= conn.private.machine_log %>"><%= conn.method %> <%= full_path(conn) %></a></li>
       <% end %>
     </ul>
   </body>

--- a/templates/log_view.html.eex
+++ b/templates/log_view.html.eex
@@ -2,29 +2,29 @@
 <html>
 <head>
     <title>Webmachine Trace <%= logconn.private.machine_log %></title>
-    <link rel="stylesheet" type="text/css" href="/wm_debug/static/wmtrace.css">
-    <link rel="stylesheet" type="text/css" href="/wm_debug/static/highlight_styles/default.css">
+    <link rel="stylesheet" type="text/css" href="../../wm_debug/static/wmtrace.css">
+    <link rel="stylesheet" type="text/css" href="../../wm_debug/static/highlight_styles/default.css">
     <link rel="icon" href="data:;base64,iVBORw0KGgo=">
-    <script src="/wm_debug/static/highlight.pack.js"></script>
-    <script src="/wm_debug/static/wmtrace.js"></script>
-    <script src="/wm_debug/static/bert.js"></script>
+    <script src="../../wm_debug/static/highlight.pack.js"></script>
+    <script src="../../wm_debug/static/wmtrace.js"></script>
+    <script src="../../wm_debug/static/bert.js"></script>
     <script>
 var obj=Bert.decode(atob("<%= logconn |> to_draw |> :erlang.term_to_binary |> Base.encode64 %>"))
 var request = obj.request
 var response = obj.response
 var trace = obj.trace
 <%= if conn.params["reload"] do %>
-;(new EventSource("/wm_debug/events")).addEventListener("new_query", function(ev){
-  window.location = "http://"+window.location.host+"/wm_debug/log/"+ev.data+"?reload=true"
+;(new EventSource("../../wm_debug/events")).addEventListener("new_query", function(ev){
+  window.location = "http://"+window.location.host+window.location.pathname.split("wm_debug")[0]+"wm_debug/log/"+ev.data+"?reload=true"
 })
 <% end %>
     </script>
 </head>
 <body>
     <%= if conn.params["reload"] do %>
-        <a href="<%= "#{Plug.Conn.full_path(conn)}" %>">Stop redirect on new query</a>
+        <a href="?">Stop redirect on new query</a>
     <% else %>
-        <a href="<%= "#{Plug.Conn.full_path(conn)}?reload=true" %>">Auto redirect on new query</a>
+        <a href="?reload=true">Auto redirect on new query</a>
     <% end %>
     <div id="zoompanel">
         <button id="zoomout">zoom out</button>


### PR DESCRIPTION
First of all, thanks for developing Ewebmachine! I am going to use it a lot and happy to contribute.

My first issue was being unable to use wm_debug at non-root locations. My resources are well below / so absolute paths in assets didn't work for me :)

This PR seemingly solves this issue.