### PR TITLE
chore: Cleanup repo

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,59 @@
+name: Build and test
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and test (Elixir ${{matrix.versions.elixir}})
+    strategy:
+      matrix:
+        versions: [{os: 'ubuntu-20.04', otp: '23.3.4.9', elixir: '1.13.4-otp-23'}, {os: 'ubuntu-22.04', otp: '25.3.2.9', elixir: '1.15.7-otp-25'}]
+    runs-on: ${{matrix.versions.os}}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Elixir
+      uses: erlef/setup-beam@v1
+      with:
+        elixir-version: ${{matrix.versions.elixir}}
+        otp-version: ${{matrix.versions.otp}}
+
+    # Define how to cache deps. Restores existing cache if present.
+    - name: Cache deps
+      id: cache-deps
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-elixir-deps
+      with:
+        path: deps
+        key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-mix-${{env.cache-name}}
+
+    # Define how to cache the `_build` directory. After the first run,
+    # this speeds up tests runs a lot. This includes not re-compiling our
+    # project's downloaded deps every run.
+    - name: Cache compiled build
+      id: cache-build
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-compiled-build
+      with:
+        path: _build
+        key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-mix-${{ env.cache-name }}-
+          ${{ runner.os }}-mix-
+
+    - name: Install dependencies
+      run: mix deps.get
+
+    - name: Run tests
+      run: mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: elixir
-notifications:
-  recipients:
-    - arnaud.wetzel@kbrwadventure.com
-elixir:
-  - '1.10.0'
-  - '1.11.0'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To do that, the library gives you 5 plugs and 2 plug pipeline builders :
   define at the same time an `Ewebmachine.Builder.Handlers` and the
   matching spec to use it, and a plug `:resource_match` to do the
   match and execute the associated plug. The macro `resources_plugs` helps you
-  to define commong plug pipeling
+  to define common plug pipeline
 
 ## Example usage
 
@@ -64,14 +64,18 @@ defmodule FullApi do
 
   resource "/hello/:name" do %{name: name} after 
     content_types_provided do: ['application/xml': :to_xml]
-    defh to_xml, do: "<Person><name>#{state.name}</name>"
+    defh to_xml, do: "<Person><name>#{state.name}</name></Person>"
   end
 
   resource "/hello/json/:name" do %{name: name} after 
     plug MyJSONApi #this is also a plug pipeline
     allowed_methods do: ["GET","DELETE"]
-    resource_exists do: pass((user=DB.get(state.name)) !== nil, json_obj: user)
     delete_resource do: DB.delete(state.name)
+
+    defh resource_exists do
+      user = DB.get(state.name)
+      pass(user !== nil, json_obj: user)
+    end
   end
 
   resource "/static/*path" do %{path: Enum.join(path,"/")} after
@@ -105,7 +109,7 @@ defmodule MyApp do
   use Application
   def start(_type, _args), do:
     Supervisor.start_link([
-        Plug.Adapters.Cowboy.child_spec(:http,FullApi,[], port: 4000)
+        Plug.Cowboy.child_spec(:http,FullApi,[], port: 4000)
       ], strategy: :one_for_one)
 end
 ```
@@ -117,7 +121,7 @@ def application do
   [applications: [:logger,:ewebmachine,:cowboy], mod: {MyApp,[]}]
 end
 defp deps, do:
-  [{:ewebmachine, "2.0.0"}, {:cowboy, "~> 1.0"}]
+  [{:ewebmachine, "2.3.2"}, {:cowboy, "~> 1.0"}]
 ```
 
 # CONTRIBUTING

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
+# Ewebmachine [![Build Status](https://github.com/kbrw/ewebmachine/actions/workflows/.github/workflows/build-and-test.yml/badge.svg)](https://github.com/kbrw/ewebmachine/actions/workflows/build-and-test.yml) [![Hex.pm](https://img.shields.io/hexpm/v/ewebmachine.svg)](https://hex.pm/packages/ewebmachine) [![Documentation](https://img.shields.io/badge/documentation-gray)](https://hexdocs.pm/ewebmachine) ![Hex.pm License](https://img.shields.io/hexpm/l/ewebmachine)
+
 Ewebmachine is a full rewrite with clean DSL and plug integration
 based on Webmachine from basho. This version is not backward compatible with
 the previous one that was only a thin wrapper around webmachine, use the branch
 1.0-legacy to use the old one.
-
-[![Build Status](https://travis-ci.org/kbrw/ewebmachine.svg?branch=master)](https://travis-ci.org/kbrw/ewebmachine)
-
-See the [generated documentation](http://hexdocs.pm/ewebmachine) for more detailed explanations.
 
 The principle is to go through the [HTTP decision tree](https://raw.githubusercontent.com/kbrw/ewebmachine/master/doc/http_diagram.png)
 and make decisions according to response of some callbacks called "handlers".

--- a/examples/hello/config/config.exs
+++ b/examples/hello/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/examples/hello/lib/hello.ex
+++ b/examples/hello/lib/hello.ex
@@ -4,13 +4,20 @@ defmodule Hello do
     
     def start(_type, _args) do
       Supervisor.start_link([
-	Plug.Adapters.Cowboy2.child_spec(scheme: :http, plug: Hello.Api, options: [port: 4000]),
-	Supervisor.Spec.worker(Hello.Db, [])
+      	Plug.Cowboy.child_spec(scheme: :http, plug: Hello.Api, options: [port: 4000]),
+        Hello.Db
       ], strategy: :one_for_one)
     end
   end
 
   defmodule Db do
+    def child_spec(_), do: %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, []},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 500
+    }
     def start_link, do: Agent.start_link(&Map.new/0, name: __MODULE__)
     def get(id), do: Agent.get(__MODULE__, &(Map.get(&1, id, nil)))
     def put(id, val), do: Agent.update(__MODULE__, &(Map.put(&1, id, val)))
@@ -100,8 +107,8 @@ defmodule Hello do
 
     resource "/static/*path" do %{path: Enum.join(path, "/")} after
       resource_exists do: File.regular?(path(state.path))
-      content_types_provided do: [ {state.path |> Plug.MIME.path() |> default_plain, :to_content} ]
-      
+      content_types_provided do: [ {state.path |> MIME.from_path() |> default_plain, :to_content} ]
+
       defh to_content(conn, state) do
 	body = File.stream!( path(state.path), [], 300_000_000)
 	{body, conn, state}

--- a/examples/hello/lib/hello.ex
+++ b/examples/hello/lib/hello.ex
@@ -38,7 +38,7 @@ defmodule Hello do
     
     resource "/hello/:name" do %{name: name} after 
       content_types_provided do: ['application/xml': :to_xml]
-      defh to_xml(conn, state), do: {"<Person><name>#{state.name}</name>", conn, state}
+      defh to_xml(conn, state), do: {"<Person><name>#{state.name}</name></Person>", conn, state}
     end
     
     resource "/hello/json/:name" do %{name: name} after 

--- a/examples/hello/mix.exs
+++ b/examples/hello/mix.exs
@@ -12,7 +12,7 @@ defmodule Hello.Mixfile do
 
   def application do
     [
-      applications: [:logger, :ewebmachine, :cowboy],
+      applications: [:logger, :ewebmachine, :cowboy, :poison],
       mod: {Hello.App, []}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Ewebmachine.Mixfile do
     [
       app: :ewebmachine,
       version: version(),
-      elixir: ">= 1.10.0",
+      elixir: ">= 1.13.4",
       docs: docs(),
       deps: deps(),
       description: @description,

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Ewebmachine.Mixfile do
   defp deps do
     [
       {:plug, "~> 1.10"},
-      {:plug_cowboy, "~> 2.4", optional: true},
+      {:plug_cowboy, "~> 2.4"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     ]


### PR DESCRIPTION
This fixes #41 

- Use github actions for CI
- Fix example to actually work
- Remove a lot of warnings

Remaining warnings are from dependencies, Poison and dializer which we may want to upgrade along with the elixir version at some point. 

Tested with elixir 1.13.4 OTP 23